### PR TITLE
Add numpy 1.23.5 to dependencies for state-estimation

### DIFF
--- a/state-estimation/dependencies-py3.txt
+++ b/state-estimation/dependencies-py3.txt
@@ -2,3 +2,4 @@
 
 aido-protocols-daffy
 duckietown-utils-daffy
+numpy==1.23.5


### PR DESCRIPTION
numpy >= 1.24 removes `np.int`, which is used by the versions of scipy that run on python 3.8, the python version used here. Downgrading to 1.23.5 eliminates this error without needing to change the python version.