### PR TITLE
Pin numpy version for braitenberg mooc ex

### DIFF
--- a/braitenberg/dependencies-py3.txt
+++ b/braitenberg/dependencies-py3.txt
@@ -4,3 +4,4 @@ aido-protocols-daffy
 duckietown-utils-daffy
 
 ipywidgets
+numpy<=1.21.0


### PR DESCRIPTION
Tested with building and running in sim

### Building
```
dts code build --recipe /path/to/this_repo
```

And these can be found in the building logs:

```
[base  8/16] RUN dt-pip3-install "/code/catkin_ws/src/braitenberg/dependencies-py3.*"                                                                                                                                                                                                       
0.479 The packages list as sent to 'pip' is:                                                                                                                                                                                                                                                
0.479                                                                                                                                                                                                                                                                                       
0.483      aido-protocols-daffy                                                                                                                                                                                                                                                             
0.483      duckietown-utils-daffy                                                                                                                                                                                                                                                           
0.483      ipywidgets                                                                                                                                                                                                                                                                       
0.483      numpy<=1.21.0 
```

### Running sim and checking numpy version in agent
``` 
dts code workbench --sim --recipe ...

# and check with
docker exec -it ex-braitenberg-agent bash
# and 
>>> import numpy as np
>>> print(np.__version__)
1.17.4
>>>
```

Simulation window and vnc run fine.