### PR TITLE
Pin numpy version for mooc exs

### DIFF
--- a/collision-checker/dependencies-py3.txt
+++ b/collision-checker/dependencies-py3.txt
@@ -3,3 +3,5 @@
 dt-protocols-daffy
 
 zuper-nodes-z6>=6.2.2
+
+numpy<=1.21.0

--- a/modcon/dependencies-py3.txt
+++ b/modcon/dependencies-py3.txt
@@ -3,3 +3,5 @@
 aido-protocols-daffy
 duckietown-world-daffy
 ipywidgets
+
+numpy<=1.21.0

--- a/visual-lane-servoing/dependencies-py3.txt
+++ b/visual-lane-servoing/dependencies-py3.txt
@@ -2,3 +2,5 @@
 
 aido-protocols-daffy
 ipympl
+
+numpy<=1.21.0


### PR DESCRIPTION
For exercises without particular version requirement of `numpy`, we pin it to `<=1.21.0` to avoid deprecated `typeDict` issue.