### PR TITLE
Update numpy dependencies-py3.txt

### DIFF
--- a/object-detection/dependencies-py3.txt
+++ b/object-detection/dependencies-py3.txt
@@ -17,7 +17,7 @@ pyglet==1.5.15
 dt-data-api>=2.1.0,<3
 
 # numpy (pinned version is needed due to incompatibilities with duckietown-world)
-numpy==1.20.0
+numpy==1.21.0
 # pandas (pinned version is to avoid this: https://stackoverflowteams.com/c/duckietown/questions/2673)
 pandas==1.4.4
 


### PR DESCRIPTION
errors on vnc container with numpy 1.20